### PR TITLE
Validate Frontira helm charts in CCI using Minikube and Kubernetes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             helm lint ./Helm/frontira/charts/mira
             helm lint ./Helm/frontira/charts/license-service
       - run:
-          name: Install Kubernetes
+          name: Install Kubectl
           command: |
             curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
       - run:
@@ -45,7 +45,7 @@ jobs:
             sudo make nsenter; sudo cp nsenter /usr/local/bin
       - run:
           name: Add docker credentials as kubernetes secret
-          command: sudo kubectl create secret docker-registry dockerhub --docker-username=$DOCKER_USER  --docker-password=$DOCKER_PASSWORD --docker-email=$DOCKER_EMAIL
+          command: sudo kubectl create secret docker-registry dockerhub --docker-username=$DOCKER_USER --docker-password=$DOCKER_PASSWORD --docker-email=$DOCKER_EMAIL
       - run:
           name: Helm init and wait for tiller to be running
           command: sudo helm init --debug; sudo kubectl rollout status -w deployment/tiller-deploy --namespace=kube-system;


### PR DESCRIPTION
In this PR we install Kubernetes, Minikube and Helm on a VM in Circle CI.

Added health checks for Mira and the License-service to validate the deployment.

This closes #9 