### PR TITLE
Reset retries for QIX Engine healtcheck in CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ jobs:
             echo "License-Service returned status code: $LICENSE_STATUS"
 
             # Verify QIX Engine health
+            RETRIES=0
             while (( ENGINE_STATUS != "200" && RETRIES != 30 )); do
               ENGINE_STATUS=$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:9076/healthcheck)
               sleep 2


### PR DESCRIPTION
Number of retries were never reset to 0 before verifying QIX Engine healtcheck for swarm mode in Circle CI. Since the variable is also used for healtcheck of the other services the job can fail incorrectly.