### PR TITLE
Update url to util-linux in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Install nsenter (needed by helm)
           command: |
-            cd /tmp; curl https://www.kernel.org/pub/linux/utils/util-linux/v2.25/util-linux-2.25.tar.gz | tar -zxf-; cd util-linux-2.25;
+            cd /tmp; curl https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.25/util-linux-2.25.tar.gz | tar -zxf-; cd util-linux-2.25;
             sudo apt-get install autopoint autoconf libtool automake
             ./configure --without-python --disable-all-programs --enable-nsenter --without-ncurses
             sudo make nsenter; sudo cp nsenter /usr/local/bin


### PR DESCRIPTION
The `util-linux` package has been moved to a mirror, so we need to update the url. The package includes `nsenter` which is needed by Helm.